### PR TITLE
商品出品ページへのルーティング実装

### DIFF
--- a/app/views/home/_cameraicon.html.haml
+++ b/app/views/home/_cameraicon.html.haml
@@ -1,3 +1,3 @@
-= link_to  "#" ,class: "sell__icon" do
+= link_to  new_product_path ,class: "sell__icon" do
   .sell__icon--text 出品
   = icon("fas", "camera", class: "sell__icon--camera")


### PR DESCRIPTION
# What
商品出品ページへのルーティング実装。

# Why
トップページの商品アイコンを押した際、商品出品ページに遷移するためにルーティングを組む。