### PR TITLE
[WIP]カテゴリテーブルとブランドテーブルを紐付ける中間テーブルの作成

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -11,7 +11,6 @@ class Product < ApplicationRecord
   belongs_to_active_hash :shipdate
   belongs_to_active_hash :status
   has_many :photos, dependent: :delete_all
-  accepts_nested_attributes_for :category, allow_destroy: true
   accepts_nested_attributes_for :photos, allow_destroy: true
   accepts_nested_attributes_for :brand, allow_destroy: true
 

--- a/db/migrate/20200215073605_create_products.rb
+++ b/db/migrate/20200215073605_create_products.rb
@@ -6,7 +6,7 @@ class CreateProducts < ActiveRecord::Migration[5.2]
       t.string :name, null: false, index: true
       t.text :description, null: false
       # t.integer :category_id, null: false
-      t.integer :size_id, null: false, foreign_key: true
+      t.integer :size_id, null: false
       t.integer :status_id, default: 1, null: false
       t.integer :condition_id, null: false
       t.integer :delivery_expense_id, null: false


### PR DESCRIPTION
# What
カテゴリテーブルとブランドテーブルを紐付ける中間テーブルの作成。
中間テーブル追加に伴うREADMEの更新。

# Why
中間テーブルを作成することで、この後に実装予定のブランド名のインクリメンタルサーチで、"現在選択されている小カテゴリ"に紐付いたブランド名のみ表示されるようになるため。
