### PR TITLE
クレカ登録本番稼働

### DIFF
--- a/app/assets/javascripts/credit.js
+++ b/app/assets/javascripts/credit.js
@@ -1,35 +1,35 @@
-// document.addEventListener(
+document.addEventListener(
   
-//   "DOMContentLoaded", (e) => {
+  "DOMContentLoaded", (e) => {
 
-//     if(document.getElementById('token_submit') != null){
-//     Payjp.setPublicKey("pk_test_98ab1743ba3dd92e8304a1c3");
-//   const btn = document.getElementById('token_submit');
-//   btn.addEventListener("click", (e) => {
-//     e.preventDefault();
+    if(document.getElementById('token_submit') != null){
+    Payjp.setPublicKey("pk_test_98ab1743ba3dd92e8304a1c3");
+  const btn = document.getElementById('token_submit');
+  btn.addEventListener("click", (e) => {
+    e.preventDefault();
 
-//     const card = {
-//       number: document.getElementById("card_number").value,
-//       cvc: document.getElementById("cvc").value,
-//       exp_month: document.getElementById("exp_month").value,
-//       exp_year: document.getElementById("exp_year").value
-//     }; 
-//     Payjp.createToken(card, (status, response) => {
-//       if (status === 200) { 
-//         $("#card_number").removeAttr("name");
-//         $("#cvc").removeAttr("name");
-//         $("#exp_month").removeAttr("name");
-//         $("#exp_year").removeAttr("name");
-//         $("#card_token").append(
-//           $('<input type="hidden" name="payjp-token">').val(response.id)
-//         );
-//         document.inputForm.submit();
-//         alert("登録が完了しました"); 
-//         } else {
-//         alert("カード情報が正しくありません。");
-//       }
-//     });
-//   });
-// }
+    const card = {
+      number: document.getElementById("card_number").value,
+      cvc: document.getElementById("cvc").value,
+      exp_month: document.getElementById("exp_month").value,
+      exp_year: document.getElementById("exp_year").value
+    }; 
+    Payjp.createToken(card, (status, response) => {
+      if (status === 200) { 
+        $("#card_number").removeAttr("name");
+        $("#cvc").removeAttr("name");
+        $("#exp_month").removeAttr("name");
+        $("#exp_year").removeAttr("name");
+        $("#card_token").append(
+          $('<input type="hidden" name="payjp-token">').val(response.id)
+        );
+        document.inputForm.submit();
+        alert("登録が完了しました"); 
+        } else {
+        alert("カード情報が正しくありません。");
+      }
+    });
+  });
+}
 
-// },false);
+},false);

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -79,26 +79,25 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   def step4_regist
-    #秘密鍵共有していないためコメントアウト
-    # Payjp.api_key = ENV['PAYJP_SECRET_KEY']
-    # if params['payjp-token'].blank?
-    #   redirect_to creditcard_regist_path, method: :get
-    # else
+    Payjp.api_key = ENV['PAYJP_SECRET_KEY']
+    if params['payjp-token'].blank?
+      redirect_to creditcard_regist_path, method: :get
+    else
 
-    #   customer = Payjp::Customer.create(
-    #     description: 'test',
-    #     email: current_user.email,
-    #     card: params['payjp-token'],
-    #     metadata: { user_id: current_user.id }
-    #   )
-    #   @card = Card.new(user_id: current_user.id, customer_id: customer.id, card_id: customer.default_card)
-    #   if @card.save
+      customer = Payjp::Customer.create(
+        description: 'test',
+        email: current_user.email,
+        card: params['payjp-token'],
+        metadata: { user_id: current_user.id }
+      )
+      @card = Card.new(user_id: current_user.id, customer_id: customer.id, card_id: customer.default_card)
+      if @card.save
         redirect_to registed_path, method: :post
 
-      # else
-      #   redirect_to creditcard_regist_path, method: :get
-      # end
-    # end
+      else
+        redirect_to creditcard_regist_path, method: :get
+      end
+    end
   end
 
   private


### PR DESCRIPTION
# what
外部APIのpay.jpを用いてのクレカ登録が可能なように修正を行った（コメントアウトの外し）

# why
クレジットカード登録機能を使えるようにすることで、
この後に控える商品購入機能の実装を行えるようにするため。