### PR TITLE
マイページ・配下のページにパンくずリストを追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,4 +19,10 @@ class ApplicationController < ActionController::Base
       username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
     end
   end
+
+  # 全ページのページタイトルの後ろに以下の文言をつける
+  def page_title
+    @title_end = " - Fmarket"
+  end
+
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,16 +7,19 @@ class UsersController < ApplicationController
   end
 
   def listing_sale
+    @title = "出品した商品 - 出品中"
     @products_sale = Product.where( user_id: current_user.id, status_id: 1)
     # ログインユーザーが出品している商品を全て取得する
   end
 
   def listing_trade
+    @title = "出品した商品 - 取引中"
     @products_trade = Product.where( user_id: current_user.id, status_id: [2, 3])
     # ログインユーザーが取引している商品を全て取得する（仮）
   end
 
   def listing_soldout
+    @title = "出品した商品 - 売却済"
     @products_soldout = Product.where( user_id: current_user.id, status_id: 4 )
     # ログインユーザーが売薬済の商品を全て取得する
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,9 +1,12 @@
 class UsersController < ApplicationController
+  before_action :page_title
+
   def show
+    @title = "マイページ" + @title_end
   end
 
   def edit
-
+    @title = "本人情報の登録" + @title_end
   end
 
   def listing_sale

--- a/app/views/users/_breadcrumb.html.haml
+++ b/app/views/users/_breadcrumb.html.haml
@@ -1,5 +1,19 @@
 - if action_name == "show"
+  - breadcrumb :mypage
+  .breadcrumb
+    .breadcrumb__list
+      = breadcrumbs separator: "&rsaquo;"
+
   -# 本人情報の登録
 - elsif action_name == "edit"
+  - breadcrumb :user_edit
+  .breadcrumb
+    .breadcrumb__list
+      = breadcrumbs separator: "&rsaquo;"
+
   -# 出品した商品の一覧画面
 - elsif action_name.include?("listing_")
+  - breadcrumb :mypage_listing, @title
+  .breadcrumb
+    .breadcrumb__list
+      = breadcrumbs separator: "&rsaquo;"

--- a/app/views/users/_breadcrumb.html.haml
+++ b/app/views/users/_breadcrumb.html.haml
@@ -1,0 +1,5 @@
+- if action_name == "show"
+  -# 本人情報の登録
+- elsif action_name == "edit"
+  -# 出品した商品の一覧画面
+- elsif action_name.include?("listing_")

--- a/app/views/users/_mypage.html.haml
+++ b/app/views/users/_mypage.html.haml
@@ -4,7 +4,8 @@
       .main-area__mypage__user-icon__detail
         = link_to "#" do
           = image_tag "test.png", size: "100x100", class: "main-area__mypage__user-icon__detail--picture"
-          .main-area__mypage__user-icon__detail--name ユーザー名
+          .main-area__mypage__user-icon__detail--name
+            = current_user.nickname
           .main-area__mypage__user-icon__detail--numbers 評価 9 出品数 10
     %ul.main-area__mypage__tabs
       %li.main-area__mypage__tabs__active-tab  お知らせ

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title){@title + @title_end}
 .header 
   = render 'products/header'
   = render "breadcrumb"

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,5 +1,6 @@
 .header 
   = render 'products/header'
+  = render "breadcrumb"
 .mypage-wrapper
   = render 'users/mypage_links'
   = render 'users/user_edit_form'

--- a/app/views/users/listing_sale.html.haml
+++ b/app/views/users/listing_sale.html.haml
@@ -1,5 +1,6 @@
 .header 
   = render 'products/header'
+  = render "breadcrumb"
 
 .mypage-wrapper
   = render 'users/mypage_links'

--- a/app/views/users/listing_sale.html.haml
+++ b/app/views/users/listing_sale.html.haml
@@ -1,4 +1,5 @@
-.header 
+- content_for(:title){@title + @title_end}
+.header
   = render 'products/header'
   = render "breadcrumb"
 

--- a/app/views/users/listing_soldout.html.haml
+++ b/app/views/users/listing_soldout.html.haml
@@ -1,5 +1,6 @@
 .header 
   = render 'products/header'
+  = render "breadcrumb"
 
 .mypage-wrapper
   = render 'users/mypage_links'

--- a/app/views/users/listing_soldout.html.haml
+++ b/app/views/users/listing_soldout.html.haml
@@ -1,4 +1,5 @@
-.header 
+- content_for(:title){@title + @title_end}
+.header
   = render 'products/header'
   = render "breadcrumb"
 

--- a/app/views/users/listing_trade.html.haml
+++ b/app/views/users/listing_trade.html.haml
@@ -1,5 +1,6 @@
 .header 
   = render 'products/header'
+  = render "breadcrumb"
 
 .mypage-wrapper
   = render 'users/mypage_links'

--- a/app/views/users/listing_trade.html.haml
+++ b/app/views/users/listing_trade.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title){@title + @title_end}
 .header 
   = render 'products/header'
   = render "breadcrumb"

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,5 +1,6 @@
 .header 
   = render 'products/header'
+  = render "breadcrumb"
 .mypage-wrapper
   = render 'users/mypage_links'
   = render 'users/mypage'

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title){@title}
 .header 
   = render 'products/header'
   = render "breadcrumb"

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -48,3 +48,21 @@ crumb :select_brand_category do |brand, category|
   link category.value
   parent :brand_all
 end
+
+# マイページへ遷移
+crumb :mypage do
+  link "マイページ", user_path(current_user)
+  parent :root
+end
+
+# 本人情報の登録画面
+crumb :user_edit do
+  link "本人情報の登録"
+  parent :mypage
+end
+
+# 出品した商品の一覧画面(出品中・取引中・売却済み)
+crumb :mypage_listing do |pagename|
+  link pagename
+  parent :mypage
+end


### PR DESCRIPTION
## What
・マイページとその配下のページ(本人情報の登録・リスティングページ)にパンくずリストを設置
・パンくずリストと同名のページタイトルを各ページに設定
※リスティングページから商品を選択した際のパンくずリストは今回実装していません(現在「マイページ＞リスティングページ＞商品」という階層構造になっていないため)

## Why
・トップページからマイページ配下のページまで、現在位置を把握・移動するため
・SEO対策、ブックマーク名・タブ表示等ユーザビリティの向上のため