### PR TITLE
トップページの商品表示ロジック変更

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,3 +26,11 @@ Metrics/LineLength:
 #'frozen_string_literal: true'を無効
 Style/FrozenStringLiteralComment:
   Enabled: false
+
+# https://github.com/rubocop-hq/rubocop/blob/v0.80.1/manual/cops_style.md#styleasciicomments を無効
+Style/AsciiComments:
+  Enabled: false
+
+# https://github.com/rubocop-hq/rubocop/blob/v0.80.1/manual/cops_lint.md#lintuselessaccessmodifier を無効
+Lint/UselessAccessModifier:
+  Enabled: false

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -207,6 +207,7 @@ class ProductsController < ApplicationController
   end
 
   private
+
   def sold_products_record
     # 取引された商品のIDを配列で取得
     @sold_product_ids = TransactionRecord.pluck(:product_id)
@@ -217,12 +218,12 @@ class ProductsController < ApplicationController
     # 取引された商品のカテゴリIDを取得
     sold_category_ids = @sold_products_record.pluck(:category_id)
     # sold_category_idsをルートIDに変換(メソッドはcategoryモデルに記載)
-    category_root_ids = Category.conversion_root_ids(sold_category_ids)
+    Category.conversion_root_ids(sold_category_ids)
   end
 
   def top4(duplicate_ids)
     # 配列の重複数を計算。多い順にハッシュに格納
-    duplicate_id_ranks = duplicate_ids.group_by(&:itself).map{ |id, i| [id, i.count] }.sort_by{ |id, total| total }.reverse.to_h
-    top4_ids = duplicate_id_ranks.keys[0..3]
+    duplicate_id_ranks = duplicate_ids.group_by(&:itself).map { |id, i| [id, i.count] }.sort_by { |_id, total| total }.reverse.to_h
+    duplicate_id_ranks.keys[0..3]
   end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -3,23 +3,16 @@ class ProductsController < ApplicationController
   before_action :set_pulldown, only: [:search, :detail_search]
   before_action :set_search_word, only: [:search, :detail_search]
   before_action :authenticate_user!, only: [:new]
+  before_action :sold_products_record, only: [:index]
   before_action :title_word
 
   def index
-    @title = @title_first + @title_introduction
-    sold_product_ids = TransactionRecord.pluck(:product_id)
-    # 取引先済みの商品中のカテゴリ・ブランド数上位４つのレコードをインスタンス変数に代入
-    @popular_categories = Product.includes(:category).where(id: sold_product_ids).group(:category_id).order('count(category_id) DESC').limit(4)
-    @popular_brands = Product.includes(:brand).where(id: sold_product_ids).group(:brand_id).order('count(brand_id) DESC').limit(4)
-    # 出品数が多いカテゴリとブランドのidを配列で取得(現在はcategory_idsと@popular_categories.pluck(:category_id)で別の値が出力されます。改善できないため一部仮仕様で実装します)
-    # category_ids = @popular_categories.pluck(:category_id)
-    brand_ids = @popular_brands.pluck(:brand_id)
-    # 人気のカテゴリとブランドの商品を新着順にインスタンス変数に代入(予定。※取引済みの商品も含む)
-    # @popular_categories_products = Product.includes(:photos).where(category_id: category_ids).order('created_at DESC')
-    @popular_brands_products = Product.includes(:photos).where(brand_id: brand_ids).order('created_at DESC')
-
-    # 新着順に商品をインスタンス変数に代入
-    @popular_categories_products = Product.includes(:photos).order('created_at DESC')
+    # トップページに表示する未取引の商品のレコードを取得(商品数が少ないためロジックはコメントアウト)
+    # @not_sold_products = Product.includes(:photos).where.not(id: @sold_product_ids)
+    @products = Product.includes(:photos)
+    # 人気の４カテゴリとブランドのレコードを取得(※レコードの順番は人気順ではないことに注意)
+    @popular_categories = Category.where(id: top4(category_root_ids))
+    @popular_brands = Brand.where(id: top4(@sold_products_record.pluck(:brand_id)))
   end
 
   def show
@@ -31,8 +24,6 @@ class ProductsController < ApplicationController
     # クリックされた商品名と同じものを取得
     @same_name_products = Product.includes(:photos).where('name like ?',"%#{@product.name}%").limit(6)
   end
-
-
 
   def new
     @title = "出品" + @title_end + " " + @title_introduction
@@ -213,5 +204,25 @@ class ProductsController < ApplicationController
       @search_word = params[:search_word]
     end
     @detail_search_word = params[:detail_search_word]
+  end
+
+  private
+  def sold_products_record
+    # 取引された商品のIDを配列で取得
+    @sold_product_ids = TransactionRecord.pluck(:product_id)
+    @sold_products_record = Product.where(id: @sold_product_ids)
+  end
+  
+  def category_root_ids
+    # 取引された商品のカテゴリIDを取得
+    sold_category_ids = @sold_products_record.pluck(:category_id)
+    # sold_category_idsをルートIDに変換(メソッドはcategoryモデルに記載)
+    category_root_ids = Category.conversion_root_ids(sold_category_ids)
+  end
+
+  def top4(duplicate_ids)
+    # 配列の重複数を計算。多い順にハッシュに格納
+    duplicate_id_ranks = duplicate_ids.group_by(&:itself).map{ |id, i| [id, i.count] }.sort_by{ |id, total| total }.reverse.to_h
+    top4_ids = duplicate_id_ranks.keys[0..3]
   end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -11,12 +11,6 @@ class Category < ApplicationRecord
   end
 
   def self.conversion_root_ids(category_ids)
-    refine_categories = Category.where(id: category_ids)
-    # category_idsをルートIDに変換
-    root_ids = []
-    refine_categories.each do |category|
-      root_ids << category.root_id
-    end
-    root_ids
+    Category.where(id: category_ids).map(&:root_id)
   end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -9,4 +9,14 @@ class Category < ApplicationRecord
       Category.find(category_id).subtree_ids
     end
   end
+
+  def self.conversion_root_ids(category_ids)
+    refine_categories = Category.where(id: category_ids)
+    # category_idsをルートIDに変換
+    root_ids = []
+    refine_categories.each do |category|
+      root_ids << category.root_id
+    end
+    return root_ids
+  end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -17,6 +17,6 @@ class Category < ApplicationRecord
     refine_categories.each do |category|
       root_ids << category.root_id
     end
-    return root_ids
+    root_ids
   end
 end

--- a/app/views/products/index.html.haml
+++ b/app/views/products/index.html.haml
@@ -36,7 +36,7 @@
             = category.value
             新着アイテム
           .products__main--more
-            = link_to "もっと見る >", "#"
+            = link_to "もっと見る >", category_path(category.id)
           .products__main--list
             -# 該当カテゴリ(以下)の未取引の新着アイテムを表示(商品の数が少ないため、現在はコメントアウト)
             -# = render partial: "list", collection: @not_sold_products.where(category_id: category.subtree_ids).order('id DESC').limit(10), as: :product
@@ -58,7 +58,7 @@
             = brand.name
             新着アイテム
           .products__main--more
-            = link_to "もっと見る >", "#"
+            = link_to "もっと見る >", brand_path(brand.id)
           .products__main--list
             -# 該当ブランドの未取引の新着アイテムを表示(商品の数が少ないため、現在はコメントアウト)
             -# = render partial: "list", collection: @not_sold_products.where(brand_id: brand.id).order('id DESC').limit(10), as: :product

--- a/app/views/products/index.html.haml
+++ b/app/views/products/index.html.haml
@@ -28,18 +28,19 @@
           -# 出品されている商品の中で人気(出品数が多い)のカテゴリーBest４を表示
           - @popular_categories.each do |category|
             %li.products__header--list
-              = category.category.value
+              = category.value
 
       - @popular_categories.each do |category|
         .products__main
           .products__main--title
-            = category.category.value
+            = category.value
             新着アイテム
           .products__main--more
             = link_to "もっと見る >", "#"
           .products__main--list
-            -# eachで回して現在のcategory_idの商品を10件商品一覧に表示
-            = render partial: "list", collection: @popular_categories_products.where(category_id: category.category_id).limit(10), as: :product
+            -# 該当カテゴリ(以下)の未取引の新着アイテムを表示(商品の数が少ないため、現在はコメントアウト)
+            -# = render partial: "list", collection: @not_sold_products.where(category_id: category.subtree_ids).order('id DESC').limit(10), as: :product
+            = render partial: "list", collection: @products.where(category_id: category.subtree_ids).order('id DESC').limit(10), as: :product
 
     .products
       .products__header
@@ -49,17 +50,18 @@
           -# 出品されている商品の中で人気(出品数が多い)のブランドBest４を表示
           - @popular_brands.each do |brand|
             %li.products__header--list
-              = brand.brand.name
+              = brand.name
 
       - @popular_brands.each do |brand|
         .products__main
           .products__main--title
-            = brand.brand.name
+            = brand.name
             新着アイテム
           .products__main--more
             = link_to "もっと見る >", "#"
           .products__main--list
-            -# eachで回して現在のbrand_idの商品を10件商品一覧に表示
-            = render partial: "list", collection: @popular_brands_products.where(brand_id: brand.brand_id).limit(10), as: :product
+            -# 該当ブランドの未取引の新着アイテムを表示(商品の数が少ないため、現在はコメントアウト)
+            -# = render partial: "list", collection: @not_sold_products.where(brand_id: brand.id).order('id DESC').limit(10), as: :product
+            = render partial: "list", collection: @products.where(brand_id: brand.id).order('id DESC').limit(10), as: :product
     = render "products/cameraicon"
     = render "products/footer"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -34,52 +34,15 @@ end
 end
 
 # products
-100.times do |n|
-  Product.create(
-    user_id: Faker::Number.within(range: 1..2),
-    name: Faker::Name.product_name,
-    description: Faker::Name.description,
-    size_id: Faker::Number.within(range: 1..10),
-    status_id: 1,
-    condition_id: Faker::Number.within(range: 1..6),
-    delivery_expense_id: Faker::Number.within(range: 1..2),
-    delivery_method_id: Faker::Number.within(range: 1..9),
-    area_id: Faker::Number.within(range: 1..47),
-    shipdate_id: Faker::Number.within(range: 1..3),
-    price: Faker::Number.within(range: 300..60000),
-    brand_id: Faker::Number.within(range: 1..30),
-    category_id: Faker::Number.within(range: 72..300)
-  )
-end
+require './db/seeds/products.rb'
 
 # photos
-100.times do |n|
-  Photo.create(
-    product_id: Faker::Number.unique.within(range: 1..100),
-    photo: open("#{Rails.root}/db/fixtures/img#{Faker::Number.within(range: 1..2)}.png")
-  )
-  Photo.create(
-    product_id: Faker::Number.within(range: 1..100),
-    photo: open("#{Rails.root}/db/fixtures/img#{Faker::Number.within(range: 1..2)}.png")
-  )
-  Photo.create(
-    product_id: Faker::Number.within(range: 1..100),
-    photo: open("#{Rails.root}/db/fixtures/img#{Faker::Number.within(range: 1..2)}.png")
-  )
-  Photo.create(
-    product_id: Faker::Number.within(range: 1..100),
-    photo: open("#{Rails.root}/db/fixtures/img#{Faker::Number.within(range: 1..2)}.png")
-  )
-  Photo.create(
-    product_id: Faker::Number.within(range: 1..100),
-    photo: open("#{Rails.root}/db/fixtures/img#{Faker::Number.within(range: 1..2)}.png")
-  )
-end
+require './db/seeds/photos.rb'
 
 # transaction_records
-20.times do |n|
+100.times do |n|
   TransactionRecord.create(
     user_id: Faker::Number.within(range: 1..2),
-    product_id: Faker::Number.unique.within(range: 1..20)
+    product_id: n + 1
   )
 end

--- a/db/seeds/photos.rb
+++ b/db/seeds/photos.rb
@@ -1,0 +1,35 @@
+# 取引済み商品100レコード
+100.times do |n|
+  Photo.create(
+    product_id: Faker::Number.unique.within(range: 1..100),
+    photo: open("#{Rails.root}/db/fixtures/img#{Faker::Number.within(range: 1..2)}.png")
+  )
+  Photo.create(
+    product_id: Faker::Number.within(range: 1..100),
+    photo: open("#{Rails.root}/db/fixtures/img#{Faker::Number.within(range: 1..2)}.png")
+  )
+end
+
+# 未取引商品100レコード
+100.times do |n|
+  Photo.create(
+    product_id: Faker::Number.unique.within(range: 101..200),
+    photo: open("#{Rails.root}/db/fixtures/img#{Faker::Number.within(range: 1..2)}.png")
+  )
+  Photo.create(
+    product_id: Faker::Number.within(range: 101..200),
+    photo: open("#{Rails.root}/db/fixtures/img#{Faker::Number.within(range: 1..2)}.png")
+  )
+  Photo.create(
+    product_id: Faker::Number.within(range: 101..200),
+    photo: open("#{Rails.root}/db/fixtures/img#{Faker::Number.within(range: 1..2)}.png")
+  )
+  Photo.create(
+    product_id: Faker::Number.within(range: 101..200),
+    photo: open("#{Rails.root}/db/fixtures/img#{Faker::Number.within(range: 1..2)}.png")
+  )
+  Photo.create(
+    product_id: Faker::Number.within(range: 101..200),
+    photo: open("#{Rails.root}/db/fixtures/img#{Faker::Number.within(range: 1..2)}.png")
+  )
+end

--- a/db/seeds/photos.rb
+++ b/db/seeds/photos.rb
@@ -1,35 +1,35 @@
 # 取引済み商品100レコード
 100.times do |n|
   Photo.create(
-    product_id: Faker::Number.unique.within(range: 1..100),
-    photo: open("#{Rails.root}/db/fixtures/img#{Faker::Number.within(range: 1..2)}.png")
+    product_id: n + 1,
+    photo:File.open("#{Rails.root}/db/fixtures/img#{Faker::Number.within(range: 1..2)}.png")
   )
   Photo.create(
     product_id: Faker::Number.within(range: 1..100),
-    photo: open("#{Rails.root}/db/fixtures/img#{Faker::Number.within(range: 1..2)}.png")
+    photo:File.open("#{Rails.root}/db/fixtures/img#{Faker::Number.within(range: 1..2)}.png")
   )
 end
 
 # 未取引商品100レコード
 100.times do |n|
   Photo.create(
-    product_id: Faker::Number.unique.within(range: 101..200),
-    photo: open("#{Rails.root}/db/fixtures/img#{Faker::Number.within(range: 1..2)}.png")
+    product_id: n + 100,
+    photo:File.open("#{Rails.root}/db/fixtures/img#{Faker::Number.within(range: 1..2)}.png")
   )
   Photo.create(
     product_id: Faker::Number.within(range: 101..200),
-    photo: open("#{Rails.root}/db/fixtures/img#{Faker::Number.within(range: 1..2)}.png")
+    photo:File.open("#{Rails.root}/db/fixtures/img#{Faker::Number.within(range: 1..2)}.png")
   )
   Photo.create(
     product_id: Faker::Number.within(range: 101..200),
-    photo: open("#{Rails.root}/db/fixtures/img#{Faker::Number.within(range: 1..2)}.png")
+    photo:File.open("#{Rails.root}/db/fixtures/img#{Faker::Number.within(range: 1..2)}.png")
   )
   Photo.create(
     product_id: Faker::Number.within(range: 101..200),
-    photo: open("#{Rails.root}/db/fixtures/img#{Faker::Number.within(range: 1..2)}.png")
+    photo:File.open("#{Rails.root}/db/fixtures/img#{Faker::Number.within(range: 1..2)}.png")
   )
   Photo.create(
     product_id: Faker::Number.within(range: 101..200),
-    photo: open("#{Rails.root}/db/fixtures/img#{Faker::Number.within(range: 1..2)}.png")
+    photo:File.open("#{Rails.root}/db/fixtures/img#{Faker::Number.within(range: 1..2)}.png")
   )
 end

--- a/db/seeds/products.rb
+++ b/db/seeds/products.rb
@@ -1,0 +1,37 @@
+# 取引済みの商品100レコード
+100.times do |n|
+  Product.create(
+    user_id: Faker::Number.within(range: 1..2),
+    name: Faker::Name.product_name,
+    description: Faker::Name.description,
+    size_id: Faker::Number.within(range: 1..10),
+    status_id: 4,
+    condition_id: Faker::Number.within(range: 1..6),
+    delivery_expense_id: Faker::Number.within(range: 1..2),
+    delivery_method_id: Faker::Number.within(range: 1..9),
+    area_id: Faker::Number.within(range: 1..47),
+    shipdate_id: Faker::Number.within(range: 1..3),
+    price: Faker::Number.within(range: 300..60000),
+    brand_id: Faker::Number.within(range: 1..30),
+    category_id: Faker::Number.within(range: 72..300)
+  )
+end
+
+# 未取引の商品100レコード
+100.times do |n|
+  Product.create(
+    user_id: Faker::Number.within(range: 1..2),
+    name: Faker::Name.product_name,
+    description: Faker::Name.description,
+    size_id: Faker::Number.within(range: 1..10),
+    status_id: 1,
+    condition_id: Faker::Number.within(range: 1..6),
+    delivery_expense_id: Faker::Number.within(range: 1..2),
+    delivery_method_id: Faker::Number.within(range: 1..9),
+    area_id: Faker::Number.within(range: 1..47),
+    shipdate_id: Faker::Number.within(range: 1..3),
+    price: Faker::Number.within(range: 300..60000),
+    brand_id: Faker::Number.within(range: 1..30),
+    category_id: Faker::Number.within(range: 72..300)
+  )
+end

--- a/db/seeds/products.rb
+++ b/db/seeds/products.rb
@@ -1,5 +1,5 @@
 # 取引済みの商品100レコード
-100.times do |n|
+100.times do |_n|
   Product.create(
     user_id: Faker::Number.within(range: 1..2),
     name: Faker::Name.product_name,
@@ -11,14 +11,14 @@
     delivery_method_id: Faker::Number.within(range: 1..9),
     area_id: Faker::Number.within(range: 1..47),
     shipdate_id: Faker::Number.within(range: 1..3),
-    price: Faker::Number.within(range: 300..60000),
+    price: Faker::Number.within(range: 300..60_000),
     brand_id: Faker::Number.within(range: 1..30),
     category_id: Faker::Number.within(range: 72..300)
   )
 end
 
 # 未取引の商品100レコード
-100.times do |n|
+100.times do |_n|
   Product.create(
     user_id: Faker::Number.within(range: 1..2),
     name: Faker::Name.product_name,
@@ -30,7 +30,7 @@ end
     delivery_method_id: Faker::Number.within(range: 1..9),
     area_id: Faker::Number.within(range: 1..47),
     shipdate_id: Faker::Number.within(range: 1..3),
-    price: Faker::Number.within(range: 300..60000),
+    price: Faker::Number.within(range: 300..60_000),
     brand_id: Faker::Number.within(range: 1..30),
     category_id: Faker::Number.within(range: 72..300)
   )


### PR DESCRIPTION
## What
トップページに商品を表示させるロジックが仮置だったため、正式な条件で商品が取得できるようにした

### 正式な条件
・取引済みの商品のカテゴリ・ブランド数で人気順のtop4を算出する
・算出した人気順の各カテゴリ・ブランドの未取引の商品(商品数が少ないのでロジックはコメントアウトしています)を新着順にトップページに並べる

※トップページでのカテゴリ・ブランドの並び順はロジックが組めなかったためtop4が順不同に並んでいます

## Why
トップページで本当の意味で人気のカテゴリ・ブランドの商品が表示されるようにするため