### PR TITLE
[WIP]出品した商品の編集　一部プルダウンが消えている問題の修正

### DIFF
--- a/app/assets/javascripts/products.js
+++ b/app/assets/javascripts/products.js
@@ -105,7 +105,7 @@ $(document).on('turbolinks:load', function(){
                       サイズ
                       <span class="form-require">必須</span>
                         <div class="sell-area__details__size__select">
-                          <select class="sell-area__details__status__default" name="product[size_id]" id="product_size_id">
+                          <select class="sell-area__details__size__default" name="product[size_id]" id="product_size_id">
                             <option value="">---</option>
                             ${insertHTML}
                           <select>

--- a/app/assets/javascripts/products_edit.js
+++ b/app/assets/javascripts/products_edit.js
@@ -5,7 +5,7 @@ $(document).on('turbolinks:load', function(){
     return false;
   }
   // 未入力項目あると、アラートが出る
-  $(document).on("click", '.sell-area__box__button--red-change', function(){
+  $('.sell-area__box').on("click", '.sell-area__box__button--red-change', function(){
     var select_forms = $('select');
     var check_size = $('#product_size_id').val();
     var check_delivery_method = $('#product_delivery_method_id').val();

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -182,6 +182,7 @@ class ProductsController < ApplicationController
                                     :area_id,
                                     :shipdate_id,
                                     :price,
+                                    brand_attributes: [:name],
                                     photos_attributes: [:photo, :_destroy, :id])
   end
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -48,6 +48,12 @@ class ProductsController < ApplicationController
     @photos = Photo.where(product_id: @product.id).order("id ASC")
     @upper_photos = @photos.limit(5)
     @down_photos = Photo.where(product_id: @product.id).order("id DESC").limit(@photos.length - 5)
+
+    # カテゴリプルダウンリストの中身
+    @current_category = Category.find(@product.category_id)
+    @root_categories = Category.where(ancestry: nil)
+    @child_categories = @current_category.root.children
+    @grandchild_categories = @current_category.parent.children
   end
 
   def update

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -37,11 +37,11 @@
       %h3.sell-area__name
         商品名
         %span.form-require  必須
-        = f.text_field :name, placeholder: "商品名（必須 40文字まで)", class: "sell-area__name__form"
+        = f.text_field :name, placeholder: "商品名（必須 40文字まで)", class: "sell-area__name__form", required: true
       %h3.sell-area__description
         商品の説明
         %span.form-require  必須
-        = f.text_area :description, placeholder: "商品の説明（必須 1,000文字以内）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。", class: "sell-area__description__textarea"
+        = f.text_area :description, placeholder: "商品の説明（必須 1,000文字以内）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。", class: "sell-area__description__textarea", required: true
     .sell-area__details
       %h3.sell-area__details__name
         商品の詳細
@@ -49,19 +49,19 @@
         カテゴリー
         %span.form-require 必須
         .sell-area__details__main-category__select
-          = f.collection_select :category_id, @root_categories, :id, :value, {selected: @current_category.root_id}, class: "sell-area__details__main-category__default"
+          = f.collection_select :category_id, @root_categories, :id, :value, {selected: @current_category.root_id}, class: "sell-area__details__main-category__default", required: true
       .category__append
         .sell-area__details__sub-category
           .sell-area__details__sub-category__select
-            = f.collection_select :category_id, @child_categories, :id, :value, {selected: @current_category.parent_id}, class: "sell-area__details__sub-category__default", id: "child_category"
+            = f.collection_select :category_id, @child_categories, :id, :value, {selected: @current_category.parent_id}, class: "sell-area__details__sub-category__default", id: "child_category", required: true
         .sell-area__details__subsub-category
           .sell-area__details__subsub-category__select
-            = f.collection_select :category_id, @grandchild_categories, :id, :value, {prompt: "---"}, class: "sell-area__details__subsub-category__default", id: "grandchild_category"
+            = f.collection_select :category_id, @grandchild_categories, :id, :value, {prompt: "---"}, class: "sell-area__details__subsub-category__default", id: "grandchild_category", required: true
         .sell-area__details__size
           サイズ
           %span.form-require 必須
           .sell-area__details__size__select
-            = f.collection_select :size_id, Size.all, :id, :value, {prompt: "---"}, class: "sell-area__details__size__default"
+            = f.collection_select :size_id, Size.all, :id, :value, {prompt: "---"}, class: "sell-area__details__size__default", required: true
       .sell-area__details__brand
         ブランド  
         %span.form-any 任意
@@ -72,7 +72,7 @@
         商品の状態
         %span.form-require 必須
         .sell-area__details__status__select
-          = f.collection_select :condition_id, Condition.all, :id, :value, {prompt: "---"}, class: "sell-area__details__status__default"
+          = f.collection_select :condition_id, Condition.all, :id, :value, {prompt: "---"}, class: "sell-area__details__status__default", required: true
     .sell-area__delivery
       %h3.sell-area__delivery__method
         配送について
@@ -82,23 +82,23 @@
         配送料の負担
         %span.form-require 必須
         .sell-area__delivery__burden__select
-          = f.collection_select :delivery_expense_id, DeliveryExpense.all, :id, :value, {prompt: "---"}, class: "sell-area__delivery__burden__default"
+          = f.collection_select :delivery_expense_id, DeliveryExpense.all, :id, :value, {prompt: "---"}, class: "sell-area__delivery__burden__default", required: true
       .delivery__way__append
         .sell-area__delivery__way#delivery__method
           配送の方法
           %span.form-require 必須
           .sell-area__delivery__way__select
-            = f.collection_select :delivery_method_id, @delivery_method, :id, :value, {prompt: "---"}, class: "sell-area__delivery__way__default"
+            = f.collection_select :delivery_method_id, @delivery_method, :id, :value, {prompt: "---"}, class: "sell-area__delivery__way__default", required: true
       .sell-area__delivery__origin
         発送元の地域
         %span.form-require 必須
         .sell-area__delivery__origin__select
-          = f.collection_select :area_id, Area.all, :id, :name, {prompt: "---"}, class: "sell-area__delivery__origin__default"
+          = f.collection_select :area_id, Area.all, :id, :name, {prompt: "---"}, class: "sell-area__delivery__origin__default", required: true
       .sell-area__delivery__days
         発送までの日数
         %span.form-require 必須
         .sell-area__delivery__days__select
-          = f.collection_select :shipdate_id, Shipdate.all, :id, :value, {prompt: "---"}, class: "sell-area__delivery__days__default"
+          = f.collection_select :shipdate_id, Shipdate.all, :id, :value, {prompt: "---"}, class: "sell-area__delivery__days__default", required: true
     .sell-area__selling
       %h3.sell-area__selling__price
         販売価格(300〜9,999,999)
@@ -110,7 +110,7 @@
           %span.form-require 必須
         .sell-area__selling--right
           ¥
-          = f.number_field :price, placeholder: "例) 300円", class: "sell-area__selling__box"
+          = f.number_field :price, placeholder: "例) 300円", class: "sell-area__selling__box", required: true
       .sell-area__selling__form-group--center
         .sell-area__selling__commission--left
           販売手数料 (10%)

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -68,6 +68,11 @@
         .sell-area__delivery__burden__select
           = f.collection_select :delivery_expense_id, DeliveryExpense.all, :id, :value, {prompt: "---"}, class: "sell-area__delivery__burden__default"
       .delivery__way__append
+        .sell-area__delivery__way#delivery__method
+          配送の方法
+          %span.form-require 必須
+          .sell-area__delivery__way__select
+            = f.collection_select :delivery_method_id, DeliveryExpense.all, :id, :value, {prompt: "---"}, class: "sell-area__delivery__way__default"
       .sell-area__delivery__origin
         発送元の地域
         %span.form-require 必須

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -57,6 +57,17 @@
         .sell-area__details__subsub-category
           .sell-area__details__subsub-category__select
             = f.collection_select :category_id, @grandchild_categories, :id, :value, {prompt: "---"}, class: "sell-area__details__subsub-category__default", id: "grandchild_category"
+        .sell-area__details__size
+          サイズ
+          %span.form-require 必須
+          .sell-area__details__size__select
+            = f.collection_select :size_id, Size.all, :id, :value, {prompt: "---"}, class: "sell-area__details__size__default"
+      .sell-area__details__brand
+        ブランド  
+        %span.form-any 任意
+        .sell-area__details__status__select
+        = f.fields_for :brand do |i|
+          = i.text_field :name , class: "sell-area__details__brand__default"
       .sell-area__details__status
         商品の状態
         %span.form-require 必須

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -49,9 +49,14 @@
         カテゴリー
         %span.form-require 必須
         .sell-area__details__main-category__select
-          = f.collection_select :category_id, Category.all.limit(13), :id, :value, {prompt: "---"}, class: "sell-area__details__main-category__default"
-      -# カテゴリの出現場所
+          = f.collection_select :category_id, @root_categories, :id, :value, {selected: @current_category.root_id}, class: "sell-area__details__main-category__default"
       .category__append
+        .sell-area__details__sub-category
+          .sell-area__details__sub-category__select
+            = f.collection_select :category_id, @child_categories, :id, :value, {selected: @current_category.parent_id}, class: "sell-area__details__sub-category__default", id: "child_category"
+        .sell-area__details__subsub-category
+          .sell-area__details__subsub-category__select
+            = f.collection_select :category_id, @grandchild_categories, :id, :value, {prompt: "---"}, class: "sell-area__details__subsub-category__default", id: "grandchild_category"
       .sell-area__details__status
         商品の状態
         %span.form-require 必須
@@ -72,7 +77,7 @@
           配送の方法
           %span.form-require 必須
           .sell-area__delivery__way__select
-            = f.collection_select :delivery_method_id, DeliveryExpense.all, :id, :value, {prompt: "---"}, class: "sell-area__delivery__way__default"
+            = f.collection_select :delivery_method_id, @delivery_method, :id, :value, {prompt: "---"}, class: "sell-area__delivery__way__default"
       .sell-area__delivery__origin
         発送元の地域
         %span.form-require 必須


### PR DESCRIPTION
## What
出品した商品の編集画面でカテゴリ、配送方法のプルダウンが初期段階では消えている問題の修正。
hamlファイルに最初からプルダウンを記載しておくことで配送方法を表示した。

## Why
商品編集の際、一度プルダウンを出してからでないと商品の保存ができない(フォームで未入力になってしまう)状態はユーザビリティが悪いため。

[![Screenshot from Gyazo](https://gyazo.com/0fab72ebbe9d66d2517937bf3351dfae/raw)](https://gyazo.com/0fab72ebbe9d66d2517937bf3351dfae)